### PR TITLE
Align AI client with concrete endpoint contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.env
+.venv

--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# DnD Music Tool
+
+Автономный бэкенд-сервис для подбора музыкальных плейлистов под сцену и жанр ролевой игры. Реализует API из технического задания, поддерживает нейросетевой выбор сцен и может использоваться фронтендом как источник подходящих ссылок на музыку.
+
+## Возможности
+- Загрузка конфигурации сцен и жанров из YAML-файла.
+- Возврат поискового запроса и подготовленных ссылок на провайдеров плейлистов для каждой сцены.
+- Интеграция с внешним нейросетевым сервисом для автоматического выбора сцены по тегам.
+- Расширенный каталог жанров и сценариев (фэнтези, стимпанк, хоррор, космооперы, пиратские истории, постапокалипсис и др.).
+- Учет параметров антидребезга (hysteresis) из конфигурации.
+- In-memory кэширование результатов на время, заданное в конфиге.
+- REST API, совместимое с Railway (FastAPI).
+
+## Запуск
+```bash
+pip install -e .[dev]
+uvicorn app.api:app --reload
+```
+
+По умолчанию используется конфигурация `config/default.yaml`. Чтобы подключить другой файл, задайте переменную окружения `MUSIC_CONFIG_PATH`:
+
+```bash
+MUSIC_CONFIG_PATH=./config/custom.yaml uvicorn app.api:app
+```
+
+## API
+### Поиск сцены вручную
+```http
+GET /api/search?genre=fantasy&scene=battle
+```
+
+### Автоподбор сцены по тегам
+```http
+POST /api/recommend
+{
+  "genre": "fantasy",
+  "tags": ["battle", "dragons"]
+}
+```
+
+Ответ содержит ту же структуру, что и `/api/search`, но дополнительно возвращает теги, уверенность модели и (если доступно) пояснение выбора.
+
+### Пример ответа
+```json
+{
+  "genre": "fantasy",
+  "scene": "battle",
+  "query": "epic fantasy battle instrumental -vocals",
+  "playlists": [
+    {
+      "provider": "youtube_music",
+      "url": "https://music.youtube.com/search?q=epic+fantasy+battle+instrumental+-vocals",
+      "description": "Поиск на YouTube Music"
+    },
+    {
+      "provider": "spotify",
+      "url": "https://open.spotify.com/search/epic+fantasy+battle+instrumental+-vocals",
+      "description": "Поиск в Spotify"
+    }
+  ],
+  "tags": ["battle", "dragons"],
+  "confidence": 0.91,
+  "reason": "stub",
+  "hysteresis": {
+    "min_confidence": 0.6,
+    "window_sec": 30,
+    "cooldown_sec": 75
+  }
+}
+```
+
+## Переменные окружения
+- `MUSIC_CONFIG_PATH` — путь к YAML-конфигу с жанрами и сценами.
+- `MUSIC_AI_ENDPOINT` — полный URL эндпоинта нейросетевого сервиса рекомендаций.
+- `MUSIC_AI_TOKEN` — опциональный Bearer-токен для авторизации при обращении к нейросети.
+
+## Тесты
+```bash
+pytest
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""DnD music tool package."""

--- a/app/ai_client.py
+++ b/app/ai_client.py
@@ -1,0 +1,106 @@
+"""Клиент для обращения к нейросетевому сервису рекомендаций."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+import httpx
+
+
+DEFAULT_ENDPOINT = "http://localhost:8081/api/v1/recommend"
+ENV_ENDPOINT = "MUSIC_AI_ENDPOINT"
+ENV_TOKEN = "MUSIC_AI_TOKEN"
+
+
+class NeuralTaggerError(RuntimeError):
+    """Базовая ошибка при обращении к нейросетевому сервису."""
+
+
+@dataclass(slots=True)
+class ScenePrediction:
+    """Результат от нейросетевого сервиса."""
+
+    scene: str
+    confidence: Optional[float] = None
+    reason: Optional[str] = None
+
+
+class NeuralTaggerClient:
+    """HTTP-клиент, вызывающий внешний сервис выбора сцены."""
+
+    def __init__(
+        self,
+        endpoint: str | None = None,
+        *,
+        timeout: float = 5.0,
+        token: str | None = None,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self._endpoint = endpoint or os.getenv(ENV_ENDPOINT, DEFAULT_ENDPOINT)
+        self._timeout = timeout
+        self._token = token or os.getenv(ENV_TOKEN)
+        self._transport = transport
+
+    def recommend_scene(self, genre: str, tags: Iterable[str]) -> ScenePrediction:
+        normalized_tags = [str(tag) for tag in tags if str(tag).strip()]
+        payload: dict[str, object] = {"genre": genre, "tags": normalized_tags}
+        if normalized_tags:
+            payload["tags_text"] = ", ".join(normalized_tags)
+        headers = {"Content-Type": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+
+        try:
+            with httpx.Client(timeout=self._timeout, transport=self._transport) as client:
+                response = client.post(self._endpoint, json=payload, headers=headers)
+        except httpx.HTTPError as exc:  # pragma: no cover - сеть может вести себя по-разному
+            raise NeuralTaggerError("Не удалось обратиться к сервису рекомендаций") from exc
+
+        if response.status_code != 200:
+            raise NeuralTaggerError(
+                f"Сервис рекомендаций вернул статус {response.status_code}: {response.text}"
+            )
+
+        data = response.json()
+
+        # API сервиса фиксирован, но на практике уже встречались варианты ответа:
+        # 1. {"scene": "battle", "confidence": 0.8, "reason": "..."}
+        # 2. {"result": {"scene": "battle", ...}}
+        # 3. {"scene": {"name": "battle", "confidence": 0.8, "comment": "..."}}
+        payload_data = data.get("result") if isinstance(data, dict) else None
+        if isinstance(payload_data, dict):
+            scene_block = payload_data.get("scene")
+            confidence = payload_data.get("confidence")
+            reason = payload_data.get("reason")
+        else:
+            scene_block = data.get("scene") if isinstance(data, dict) else None
+            confidence = data.get("confidence") if isinstance(data, dict) else None
+            reason = data.get("reason") if isinstance(data, dict) else None
+
+        raw_scene: Optional[str]
+        if isinstance(scene_block, dict):
+            raw_scene = (
+                scene_block.get("name")
+                or scene_block.get("value")
+                or scene_block.get("slug")
+                or scene_block.get("scene")
+            )
+            confidence = confidence or scene_block.get("confidence") or scene_block.get("score")
+            reason = reason or scene_block.get("reason") or scene_block.get("comment") or scene_block.get("explanation")
+        else:
+            raw_scene = scene_block
+            if isinstance(data, dict) and confidence is None:
+                confidence = data.get("score")
+            if isinstance(data, dict) and reason is None:
+                reason = data.get("comment") or data.get("explanation")
+
+        if not raw_scene:
+            raise NeuralTaggerError("Ответ сервиса не содержит сцены")
+
+        if confidence is not None:
+            try:
+                confidence = float(confidence)
+            except (TypeError, ValueError) as exc:  # pragma: no cover - защитный код
+                raise NeuralTaggerError("Неверное значение confidence в ответе сервиса") from exc
+        return ScenePrediction(scene=str(raw_scene).lower(), confidence=confidence, reason=reason)

--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,76 @@
+"""FastAPI application exposing the music search API."""
+from __future__ import annotations
+
+from functools import lru_cache
+
+from fastapi import Depends, FastAPI, HTTPException, Query
+
+from .config import load_config
+from .models import (
+    HealthStatus,
+    MusicConfig,
+    RecommendationRequest,
+    RecommendationResult,
+    SearchResult,
+)
+from .music_service import (
+    GenreNotFoundError,
+    MusicService,
+    RecommendationUnavailableError,
+    SceneNotFoundError,
+)
+from .ai_client import NeuralTaggerClient
+
+
+app = FastAPI(title="DnD Music Tool", version="0.1.0")
+
+
+@lru_cache(maxsize=1)
+def get_config() -> MusicConfig:
+    return load_config()
+
+
+@lru_cache(maxsize=1)
+def get_ai_client() -> NeuralTaggerClient:
+    return NeuralTaggerClient()
+
+
+@lru_cache(maxsize=1)
+def get_service_cached() -> MusicService:
+    return MusicService(get_config(), ai_client=get_ai_client())
+
+
+def get_service() -> MusicService:
+    return get_service_cached()
+
+
+@app.get("/", response_model=HealthStatus)
+async def health(service: MusicService = Depends(get_service)) -> HealthStatus:
+    return HealthStatus(genres=list(service.available_genres()))
+
+
+@app.get("/api/search", response_model=SearchResult)
+async def search(
+    genre: str = Query(..., description="Genre of the campaign, e.g. fantasy"),
+    scene: str = Query(..., description="Scene tag, e.g. battle"),
+    service: MusicService = Depends(get_service),
+) -> SearchResult:
+    try:
+        return service.search(genre, scene)
+    except GenreNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except SceneNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.post("/api/recommend", response_model=RecommendationResult)
+async def recommend(
+    request: RecommendationRequest,
+    service: MusicService = Depends(get_service),
+) -> RecommendationResult:
+    try:
+        return service.recommend(request.genre, request.tags)
+    except GenreNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RecommendationUnavailableError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc

--- a/app/cache.py
+++ b/app/cache.py
@@ -1,0 +1,44 @@
+"""Простейший in-memory TTL кэш."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Dict, Generic, Optional, Tuple, TypeVar
+
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+@dataclass
+class _CacheEntry(Generic[V]):
+    value: V
+    expires_at: float
+
+
+class TTLCache(Generic[K, V]):
+    """Неблокирующий кэш с абсолютным временем жизни."""
+
+    def __init__(self, ttl_seconds: int) -> None:
+        self._ttl = ttl_seconds
+        self._storage: Dict[K, _CacheEntry[V]] = {}
+
+    def get(self, key: K) -> Optional[V]:
+        entry = self._storage.get(key)
+        if not entry:
+            return None
+        if entry.expires_at < time.time():
+            self._storage.pop(key, None)
+            return None
+        return entry.value
+
+    def set(self, key: K, value: V) -> None:
+        expires_at = time.time() + self._ttl
+        self._storage[key] = _CacheEntry(value=value, expires_at=expires_at)
+
+    def clear(self) -> None:
+        self._storage.clear()
+
+    def stats(self) -> Tuple[int, int]:
+        """Возвращает количество элементов и TTL."""
+        return len(self._storage), self._ttl

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,34 @@
+"""Helpers to load configuration from YAML."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from .models import MusicConfig
+
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "default.yaml"
+ENV_CONFIG_PATH = "MUSIC_CONFIG_PATH"
+
+
+def _normalize_keys(data: Any) -> Any:
+    """Понижает регистр ключей словарей для сопоставления жанров/сцен."""
+    if isinstance(data, dict):
+        return {str(k).lower(): _normalize_keys(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_normalize_keys(item) for item in data]
+    return data
+
+
+def load_config(path: Path | None = None) -> MusicConfig:
+    """Loads config from YAML file."""
+    config_path = path or Path(os.getenv(ENV_CONFIG_PATH, DEFAULT_CONFIG_PATH))
+    with open(config_path, "r", encoding="utf-8") as fh:
+        raw_data: Dict[str, Any] = yaml.safe_load(fh)
+    normalized = raw_data.copy()
+    if "genres" in normalized:
+        normalized["genres"] = _normalize_keys(normalized["genres"])
+    return MusicConfig.model_validate(normalized)

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,119 @@
+"""Domain and API models for the music service."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from urllib.parse import quote_plus
+
+from pydantic import BaseModel, Field, HttpUrl, field_validator
+
+
+class PlaylistProviderConfig(BaseModel):
+    """Описание провайдера плейлистов и способ построения ссылки поиска."""
+
+    name: str = Field(..., description="Человекочитаемое имя провайдера")
+    url_template: str = Field(
+        ..., description="URL-шаблон со вставкой {query} для поисковой строки"
+    )
+    description: Optional[str] = Field(
+        None, description="Опциональное описание для отображения фронтендом"
+    )
+
+    @field_validator("url_template")
+    @classmethod
+    def _check_template(cls, value: str) -> str:
+        if "{query}" not in value:
+            raise ValueError("url_template must contain '{query}' placeholder")
+        return value
+
+    def build_search(self, query: str) -> "PlaylistSearch":
+        encoded = quote_plus(query)
+        url = self.url_template.format(query=encoded)
+        return PlaylistSearch(provider=self.name, url=url, description=self.description)
+
+
+class PlaylistSearch(BaseModel):
+    """Готовая ссылка на поиск плейлиста у внешнего провайдера."""
+
+    provider: str = Field(..., description="Название провайдера (например, YouTube)")
+    url: HttpUrl = Field(..., description="Сформированный URL поиска")
+    description: Optional[str] = Field(None, description="Описание для UI")
+
+
+class SceneConfig(BaseModel):
+    """Настройки сцены внутри жанра."""
+
+    query: str = Field(..., description="Поисковый запрос для внешних API")
+    volume: Optional[int] = Field(None, ge=0, le=100, description="Рекомендуемая громкость")
+    crossfade: Optional[int] = Field(None, ge=0, le=30, description="Время кроссфейда в секундах")
+    cooldown_sec: Optional[int] = Field(
+        None, ge=0, description="Рекомендуемое значение антидребезга"
+    )
+    providers: List[PlaylistProviderConfig] = Field(
+        default_factory=list, description="Список провайдеров плейлистов"
+    )
+
+
+class HysteresisConfig(BaseModel):
+    """Параметры антидребезга, возвращаемые фронтенду."""
+
+    min_confidence: float = Field(..., ge=0.0, le=1.0)
+    window_sec: int = Field(..., ge=1)
+    cooldown_sec: int = Field(..., ge=0)
+    cache_ttl_sec: int = Field(600, ge=0, description="Время жизни кэша в секундах")
+
+
+class MusicConfig(BaseModel):
+    """Вся конфигурация проекта."""
+
+    genres: Dict[str, Dict[str, SceneConfig]]
+    hysteresis: HysteresisConfig
+
+    def get_scene(self, genre: str, scene: str) -> SceneConfig:
+        genre_key = genre.lower()
+        scene_key = scene.lower()
+        if genre_key not in self.genres:
+            raise KeyError(f"Unknown genre: {genre}")
+        scenes = self.genres[genre_key]
+        if scene_key not in scenes:
+            raise KeyError(f"Unknown scene '{scene}' for genre '{genre}'")
+        return scenes[scene_key]
+
+
+class SearchResult(BaseModel):
+    """Результат поискового запроса."""
+
+    genre: str
+    scene: str
+    query: str
+    playlists: List[PlaylistSearch]
+    hysteresis: HysteresisConfig
+
+
+class RecommendationRequest(BaseModel):
+    """Запрос на рекомендацию сцены по тегам."""
+
+    genre: str = Field(..., description="Жанр кампании")
+    tags: List[str] = Field(..., min_length=1, description="Набор тегов от детектора событий")
+
+
+class RecommendationResult(SearchResult):
+    """Расширенный результат, дополненный данными от нейросети."""
+
+    tags: List[str] = Field(..., description="Теги, на основе которых принималось решение")
+    confidence: Optional[float] = Field(
+        None,
+        ge=0.0,
+        le=1.0,
+        description="Уверенность нейросетевого сервиса",
+    )
+    reason: Optional[str] = Field(
+        None, description="Текстовое объяснение от модели, если доступно"
+    )
+
+
+class HealthStatus(BaseModel):
+    """Состояние сервиса для эндпоинта здоровья."""
+
+    status: str = "ok"
+    genres: List[str] = Field(default_factory=list)

--- a/app/music_service.py
+++ b/app/music_service.py
@@ -1,0 +1,106 @@
+"""Business logic for matching music scenes and genres."""
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+from .cache import TTLCache
+from .models import (
+    MusicConfig,
+    RecommendationResult,
+    SceneConfig,
+    SearchResult,
+)
+from .ai_client import NeuralTaggerClient, NeuralTaggerError, ScenePrediction
+
+
+class MusicServiceError(Exception):
+    """Base error for the music service."""
+
+
+class GenreNotFoundError(MusicServiceError):
+    """Raised when requested genre does not exist."""
+
+
+class SceneNotFoundError(MusicServiceError):
+    """Raised when scene does not exist inside selected genre."""
+
+
+class RecommendationUnavailableError(MusicServiceError):
+    """Raised when neural recommendations cannot be produced."""
+
+
+class MusicService:
+    """Entry point for search logic."""
+
+    def __init__(
+        self, config: MusicConfig, *, ai_client: NeuralTaggerClient | None = None
+    ) -> None:
+        self._config = config
+        self._cache = TTLCache[Tuple[str, str], SearchResult](config.hysteresis.cache_ttl_sec)
+        self._ai_client = ai_client
+
+    def _get_scene_config(self, genre: str, scene: str) -> SceneConfig:
+        try:
+            return self._config.get_scene(genre, scene)
+        except KeyError as exc:
+            message = exc.args[0] if exc.args else str(exc)
+            if message.startswith("Unknown genre"):
+                raise GenreNotFoundError(message) from exc
+            raise SceneNotFoundError(message) from exc
+
+    def search(self, genre: str, scene: str) -> SearchResult:
+        cache_key = (genre.lower(), scene.lower())
+        cached = self._cache.get(cache_key)
+        if cached:
+            return cached
+
+        scene_config = self._get_scene_config(genre, scene)
+
+        playlists = [provider.build_search(scene_config.query) for provider in scene_config.providers]
+
+        result = SearchResult(
+            genre=cache_key[0],
+            scene=cache_key[1],
+            query=scene_config.query,
+            playlists=playlists,
+            hysteresis=self._config.hysteresis,
+        )
+        self._cache.set(cache_key, result)
+        return result
+
+    def available_genres(self) -> Tuple[str, ...]:
+        return tuple(sorted(self._config.genres.keys()))
+
+    def recommend(self, genre: str, tags: Iterable[str]) -> RecommendationResult:
+        if not tags:
+            raise RecommendationUnavailableError("Нужен хотя бы один тег для рекомендации")
+        if not self._ai_client:
+            raise RecommendationUnavailableError("Сервис рекомендаций не настроен")
+
+        prediction = self._call_ai(genre, tags)
+        base_result = self.search(genre, prediction.scene)
+        return RecommendationResult(
+            genre=base_result.genre,
+            scene=base_result.scene,
+            query=base_result.query,
+            playlists=base_result.playlists,
+            hysteresis=base_result.hysteresis,
+            tags=list(tags),
+            confidence=prediction.confidence,
+            reason=prediction.reason,
+        )
+
+    def _call_ai(self, genre: str, tags: Iterable[str]) -> ScenePrediction:
+        try:
+            prediction = self._ai_client.recommend_scene(genre, tags)  # type: ignore[union-attr]
+        except NeuralTaggerError as exc:
+            raise RecommendationUnavailableError(str(exc)) from exc
+
+        # проверяем, что выбранная сцена действительно существует
+        try:
+            self._get_scene_config(genre, prediction.scene)
+        except SceneNotFoundError as exc:
+            raise RecommendationUnavailableError(
+                f"Нейросеть вернула неизвестную сцену '{prediction.scene}'"
+            ) from exc
+        return prediction

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,0 +1,353 @@
+genres:
+  fantasy:
+    battle:
+      query: "epic fantasy battle instrumental -vocals"
+      volume: 85
+      crossfade: 3
+      cooldown_sec: 75
+      providers:
+        - name: youtube_music
+          description: "Поиск на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+        - name: spotify
+          description: "Поиск в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+    tavern:
+      query: "medieval tavern lute folk instrumental -vocals"
+      volume: 70
+      crossfade: 5
+      cooldown_sec: 90
+      providers:
+        - name: youtube_music
+          description: "Атмосферные треки таверны на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+        - name: yandex_music
+          description: "Поиск на Яндекс Музыке"
+          url_template: "https://music.yandex.ru/search?text={query}"
+    exploration:
+      query: "fantasy ambient forest exploration instrumental -vocals"
+      volume: 60
+      crossfade: 6
+      cooldown_sec: 120
+      providers:
+        - name: spotify
+          description: "Прогулки по зачарованным лесам в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+        - name: apple_music
+          description: "Поиск атмосферного эмбиента в Apple Music"
+          url_template: "https://music.apple.com/us/search?term={query}"
+    ritual:
+      query: "mystic fantasy ritual choir drones instrumental -vocals"
+      volume: 50
+      crossfade: 8
+      cooldown_sec: 150
+      providers:
+        - name: youtube_music
+          description: "Хоры и ритуальные напевы на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+        - name: bandcamp
+          description: "Поиск ритуальных эмбиентов на Bandcamp"
+          url_template: "https://bandcamp.com/search?q={query}&item_type=music"
+  cyberpunk:
+    battle:
+      query: "cyberpunk combat synthwave instrumental -vocals"
+      volume: 85
+      crossfade: 3
+      cooldown_sec: 75
+      providers:
+        - name: youtube_music
+          description: "Синтвейв для боев на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+        - name: deezer
+          description: "Поиск плейлистов на Deezer"
+          url_template: "https://www.deezer.com/search/{query}"
+    tavern:
+      query: "cyberpunk bar neon synth lounge instrumental -vocals"
+      volume: 70
+      crossfade: 5
+      cooldown_sec: 90
+      providers:
+        - name: spotify
+          description: "Неоновые барные плейлисты в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+        - name: soundcloud
+          description: "Найти миксы на SoundCloud"
+          url_template: "https://soundcloud.com/search/sounds?q={query}"
+    chase:
+      query: "cyberpunk high speed chase dnb instrumental -vocals"
+      volume: 80
+      crossfade: 3
+      cooldown_sec: 75
+      providers:
+        - name: youtube_music
+          description: "Драм-н-бейс для погонь на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+        - name: deezer
+          description: "Поиск энергичных плейлистов на Deezer"
+          url_template: "https://www.deezer.com/search/{query}"
+    infiltration:
+      query: "cyberpunk stealth ambient pulse instrumental -vocals"
+      volume: 55
+      crossfade: 6
+      cooldown_sec: 120
+      providers:
+        - name: tidal
+          description: "Хай-тек напряжение в Tidal"
+          url_template: "https://listen.tidal.com/search/{query}"
+        - name: spotify
+          description: "Неоновые стелс-эмбиенты в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+  sci-fi:
+    battle:
+      query: "space opera battle orchestral instrumental -vocals"
+      volume: 85
+      crossfade: 3
+      cooldown_sec: 75
+      providers:
+        - name: youtube_music
+          description: "Эпические космические битвы на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+        - name: apple_music
+          description: "Поиск на Apple Music"
+          url_template: "https://music.apple.com/us/search?term={query}"
+    exploration:
+      query: "sci fi ambient exploration instrumental -vocals"
+      volume: 65
+      crossfade: 4
+      cooldown_sec: 90
+      providers:
+        - name: spotify
+          description: "Космический эмбиент в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+        - name: youtube_music
+          description: "Атмосферные плейлисты на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+    research:
+      query: "sci fi laboratory pulses minimal instrumental -vocals"
+      volume: 55
+      crossfade: 5
+      cooldown_sec: 120
+      providers:
+        - name: apple_music
+          description: "Научные синтезаторы в Apple Music"
+          url_template: "https://music.apple.com/us/search?term={query}"
+        - name: deezer
+          description: "Поиск лабораторных эмбиентов на Deezer"
+          url_template: "https://www.deezer.com/search/{query}"
+    anomaly:
+      query: "cosmic horror anomaly textures instrumental -vocals"
+      volume: 50
+      crossfade: 7
+      cooldown_sec: 150
+      providers:
+        - name: youtube_music
+          description: "Загадочные сигналы на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+        - name: spotify
+          description: "Инопланетные звуки в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+  horror:
+    tension:
+      query: "dark horror suspense ambient drone instrumental -vocals"
+      volume: 60
+      crossfade: 4
+      cooldown_sec: 90
+      providers:
+        - name: youtube_music
+          description: "Жуткие эмбиентные треки на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+        - name: spotify
+          description: "Хоррор-плейлисты в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+    exploration:
+      query: "creepy dungeon ambient instrumental -vocals"
+      volume: 55
+      crossfade: 5
+      cooldown_sec: 90
+      providers:
+        - name: soundcloud
+          description: "Поиск жутких эмбиентов на SoundCloud"
+          url_template: "https://soundcloud.com/search/sounds?q={query}"
+        - name: youtube_music
+          description: "Темные данжи на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+    ritual:
+      query: "occult ritual chanting bells instrumental -vocals"
+      volume: 45
+      crossfade: 8
+      cooldown_sec: 150
+      providers:
+        - name: spotify
+          description: "Темные обряды в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+        - name: bandcamp
+          description: "Ритуальные эмбиенты на Bandcamp"
+          url_template: "https://bandcamp.com/search?q={query}&item_type=music"
+    pursuit:
+      query: "horror chase heartbeat percussion instrumental -vocals"
+      volume: 75
+      crossfade: 4
+      cooldown_sec: 90
+      providers:
+        - name: youtube_music
+          description: "Напряженные погони на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+        - name: tidal
+          description: "Перкуссионный ужас в Tidal"
+          url_template: "https://listen.tidal.com/search/{query}"
+  post_apocalyptic:
+    wasteland_travel:
+      query: "post apocalyptic acoustic wanderer instrumental -vocals"
+      volume: 65
+      crossfade: 5
+      cooldown_sec: 120
+      providers:
+        - name: spotify
+          description: "Пыльные дороги в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+        - name: youtube_music
+          description: "Блуждания по пустошам на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+    raider_attack:
+      query: "post apocalyptic battle percussion guitars instrumental -vocals"
+      volume: 80
+      crossfade: 4
+      cooldown_sec: 90
+      providers:
+        - name: deezer
+          description: "Рейдерские нападения на Deezer"
+          url_template: "https://www.deezer.com/search/{query}"
+        - name: yandex_music
+          description: "Поиск агрессивных плейлистов на Яндекс Музыке"
+          url_template: "https://music.yandex.ru/search?text={query}"
+  steampunk:
+    airship_voyage:
+      query: "steampunk airship adventure instrumental -vocals"
+      volume: 70
+      crossfade: 5
+      cooldown_sec: 120
+      providers:
+        - name: spotify
+          description: "Дирижабельные приключения в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+        - name: bandcamp
+          description: "Паровой стимпанк на Bandcamp"
+          url_template: "https://bandcamp.com/search?q={query}&item_type=music"
+    clockwork_heist:
+      query: "steampunk heist clockwork jazz instrumental -vocals"
+      volume: 65
+      crossfade: 6
+      cooldown_sec: 120
+      providers:
+        - name: youtube_music
+          description: "Механические аферы на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+        - name: apple_music
+          description: "Поиск механического джаза в Apple Music"
+          url_template: "https://music.apple.com/us/search?term={query}"
+  modern_espionage:
+    stakeout:
+      query: "spy thriller tension pulses instrumental -vocals"
+      volume: 55
+      crossfade: 5
+      cooldown_sec: 90
+      providers:
+        - name: tidal
+          description: "Наблюдение и напряжение в Tidal"
+          url_template: "https://listen.tidal.com/search/{query}"
+        - name: spotify
+          description: "Шпионские пульсации в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+    action:
+      query: "modern spy action hybrid orchestral instrumental -vocals"
+      volume: 75
+      crossfade: 4
+      cooldown_sec: 90
+      providers:
+        - name: youtube_music
+          description: "Экшен-шпионаж на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+        - name: soundcloud
+          description: "Современные шпионские биты на SoundCloud"
+          url_template: "https://soundcloud.com/search/sounds?q={query}"
+  pirate:
+    high_seas:
+      query: "pirate adventure orchestral shanty instrumental -vocals"
+      volume: 80
+      crossfade: 5
+      cooldown_sec: 120
+      providers:
+        - name: spotify
+          description: "Морские приключения в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+        - name: youtube_music
+          description: "Шанти и оркестры на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+    tavern_brawl:
+      query: "pirate tavern fight fiddle instrumental -vocals"
+      volume: 75
+      crossfade: 5
+      cooldown_sec: 120
+      providers:
+        - name: bandcamp
+          description: "Пиратские драки на Bandcamp"
+          url_template: "https://bandcamp.com/search?q={query}&item_type=music"
+        - name: yandex_music
+          description: "Веселые потасовки на Яндекс Музыке"
+          url_template: "https://music.yandex.ru/search?text={query}"
+  wild_west:
+    duel:
+      query: "wild west duel spaghetti western instrumental -vocals"
+      volume: 75
+      crossfade: 3
+      cooldown_sec: 90
+      providers:
+        - name: youtube_music
+          description: "Дуэли в стиле вестерн на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+        - name: spotify
+          description: "Спагетти-вестерн в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+    travel:
+      query: "western frontier travel acoustic instrumental -vocals"
+      volume: 65
+      crossfade: 5
+      cooldown_sec: 120
+      providers:
+        - name: deezer
+          description: "Поиск дорог фронтира на Deezer"
+          url_template: "https://www.deezer.com/search/{query}"
+        - name: apple_music
+          description: "Песни ковбоев в Apple Music"
+          url_template: "https://music.apple.com/us/search?term={query}"
+  mythic:
+    celestial:
+      query: "mythic celestial choir ambient instrumental -vocals"
+      volume: 55
+      crossfade: 7
+      cooldown_sec: 150
+      providers:
+        - name: spotify
+          description: "Небесные хоры в Spotify"
+          url_template: "https://open.spotify.com/search/{query}"
+        - name: youtube_music
+          description: "Возвышенные напевы на YouTube Music"
+          url_template: "https://music.youtube.com/search?q={query}"
+    underworld:
+      query: "mythic underworld dark ambient instrumental -vocals"
+      volume: 50
+      crossfade: 6
+      cooldown_sec: 150
+      providers:
+        - name: tidal
+          description: "Подземные реки в Tidal"
+          url_template: "https://listen.tidal.com/search/{query}"
+        - name: bandcamp
+          description: "Мифические глубины на Bandcamp"
+          url_template: "https://bandcamp.com/search?q={query}&item_type=music"
+
+hysteresis:
+  min_confidence: 0.6
+  window_sec: 30
+  cooldown_sec: 75
+  cache_ttl_sec: 600

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dnd-music-tool"
+version = "0.1.0"
+description = "Backend tool for retrieving RPG music tracks by scene and genre"
+authors = [{name = "DnD Music Tool"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.110",
+    "uvicorn>=0.29",
+    "pydantic>=2.6",
+    "pyyaml>=6.0",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.1",
+]
+
+[tool.setuptools]
+packages = ["app"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+app = []
+
+[tool.pytest.ini_options]
+addopts = "-q"
+pythonpath = ["."]

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -1,0 +1,52 @@
+import json
+
+import pytest
+import httpx
+
+from app.ai_client import NeuralTaggerClient, NeuralTaggerError
+
+
+def test_neural_client_success() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        payload = json.loads(request.content.decode())
+        assert payload["genre"] == "fantasy"
+        assert payload["tags"] == ["battle"]
+        assert payload["tags_text"] == "battle"
+        return httpx.Response(200, json={"scene": "battle", "confidence": 0.88, "reason": "stub"})
+
+    client = NeuralTaggerClient(endpoint="http://test", transport=httpx.MockTransport(handler))
+    prediction = client.recommend_scene("fantasy", ["battle"])
+    assert prediction.scene == "battle"
+    assert prediction.confidence == pytest.approx(0.88)
+    assert prediction.reason == "stub"
+
+
+def test_neural_client_error_status() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "boom"})
+
+    client = NeuralTaggerClient(endpoint="http://test", transport=httpx.MockTransport(handler))
+    with pytest.raises(NeuralTaggerError):
+        client.recommend_scene("fantasy", ["battle"])
+
+
+def test_neural_client_nested_scene() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode())
+        assert payload["tags_text"] == "battle, dragons"
+        return httpx.Response(
+            200,
+            json={
+                "result": {
+                    "scene": {"name": "BATTLE", "confidence": 0.73, "comment": "ok"},
+                    "reason": "extra",
+                }
+            },
+        )
+
+    client = NeuralTaggerClient(endpoint="http://test", transport=httpx.MockTransport(handler))
+    prediction = client.recommend_scene("fantasy", ["battle", "dragons"])
+    assert prediction.scene == "battle"
+    assert prediction.confidence == pytest.approx(0.73)
+    assert prediction.reason == "extra"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,74 @@
+from fastapi.testclient import TestClient
+
+from app.api import app, get_ai_client, get_config, get_service, get_service_cached
+from app.music_service import MusicService
+from app.config import load_config
+from app.ai_client import ScenePrediction
+
+
+def _reset_caches() -> None:
+    get_service_cached.cache_clear()
+    get_config.cache_clear()
+    get_ai_client.cache_clear()
+
+
+def test_health_endpoint(monkeypatch) -> None:
+    monkeypatch.setenv("MUSIC_CONFIG_PATH", "config/default.yaml")
+    _reset_caches()
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert "fantasy" in data["genres"]
+
+
+def test_search_endpoint(monkeypatch) -> None:
+    monkeypatch.setenv("MUSIC_CONFIG_PATH", "config/default.yaml")
+    _reset_caches()
+    client = TestClient(app)
+    response = client.get("/api/search", params={"genre": "horror", "scene": "tension"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["genre"] == "horror"
+    assert payload["scene"] == "tension"
+    assert len(payload["playlists"]) >= 1
+
+
+def test_search_unknown_scene(monkeypatch) -> None:
+    monkeypatch.setenv("MUSIC_CONFIG_PATH", "config/default.yaml")
+    _reset_caches()
+    client = TestClient(app)
+    response = client.get("/api/search", params={"genre": "horror", "scene": "party"})
+    assert response.status_code == 404
+
+
+def test_recommend_endpoint(monkeypatch) -> None:
+    monkeypatch.setenv("MUSIC_CONFIG_PATH", "config/default.yaml")
+    _reset_caches()
+
+    class StubAI:
+        def recommend_scene(self, genre: str, tags):
+            assert genre == "fantasy"
+            assert tags == ["battle", "dragons"]
+            return ScenePrediction(scene="battle", confidence=0.91, reason="stub")
+
+    service = MusicService(load_config(), ai_client=StubAI())
+
+    client = TestClient(app)
+    app.dependency_overrides[get_service] = lambda: service
+
+    response = client.post(
+        "/api/recommend",
+        json={"genre": "fantasy", "tags": ["battle", "dragons"]},
+    )
+
+    try:
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["scene"] == "battle"
+        assert payload["confidence"] == 0.91
+        assert payload["tags"] == ["battle", "dragons"]
+        assert payload["reason"] == "stub"
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+import pytest
+
+from app.config import load_config
+from app.models import MusicConfig
+
+
+def test_load_config_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_path = Path("config/default.yaml").resolve()
+    monkeypatch.setenv("MUSIC_CONFIG_PATH", str(config_path))
+    config = load_config()
+    assert isinstance(config, MusicConfig)
+    assert "fantasy" in config.genres
+    assert config.hysteresis.cache_ttl_sec == 600

--- a/tests/test_music_service.py
+++ b/tests/test_music_service.py
@@ -1,0 +1,82 @@
+import pytest
+
+from app.config import load_config
+from app.music_service import (
+    GenreNotFoundError,
+    MusicService,
+    RecommendationUnavailableError,
+    SceneNotFoundError,
+)
+from app.ai_client import ScenePrediction
+
+
+@pytest.fixture()
+def service(monkeypatch: pytest.MonkeyPatch) -> MusicService:
+    config_path = "config/default.yaml"
+    monkeypatch.setenv("MUSIC_CONFIG_PATH", config_path)
+    return MusicService(load_config())
+
+
+@pytest.fixture()
+def service_with_ai(monkeypatch: pytest.MonkeyPatch) -> MusicService:
+    config_path = "config/default.yaml"
+    monkeypatch.setenv("MUSIC_CONFIG_PATH", config_path)
+
+    class StubAI:
+        def recommend_scene(self, genre: str, tags):
+            assert genre in {"fantasy", "cyberpunk"}
+            assert tags
+            return ScenePrediction(scene="battle", confidence=0.85, reason="stub")
+
+    return MusicService(load_config(), ai_client=StubAI())
+
+
+def test_search_returns_playlists(service: MusicService) -> None:
+    result = service.search("fantasy", "battle")
+    assert result.genre == "fantasy"
+    assert result.scene == "battle"
+    assert result.playlists
+    first = result.playlists[0]
+    assert first.provider
+    assert str(first.url).startswith("https://")
+
+
+def test_search_uses_cache(service: MusicService) -> None:
+    first = service.search("cyberpunk", "tavern")
+    second = service.search("cyberpunk", "tavern")
+    assert first is second
+
+
+def test_unknown_genre(service: MusicService) -> None:
+    with pytest.raises(GenreNotFoundError):
+        service.search("western", "battle")
+
+
+def test_unknown_scene(service: MusicService) -> None:
+    with pytest.raises(SceneNotFoundError):
+        service.search("fantasy", "romance")
+
+
+def test_recommend_uses_ai(service_with_ai: MusicService) -> None:
+    result = service_with_ai.recommend("fantasy", ["battle", "dragons"])
+    assert result.scene == "battle"
+    assert result.confidence == 0.85
+    assert result.tags == ["battle", "dragons"]
+
+
+def test_recommend_without_ai(service: MusicService) -> None:
+    with pytest.raises(RecommendationUnavailableError):
+        service.recommend("fantasy", ["battle"])
+
+
+def test_recommend_invalid_scene(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MUSIC_CONFIG_PATH", "config/default.yaml")
+
+    class WrongAI:
+        def recommend_scene(self, genre: str, tags):
+            return ScenePrediction(scene="nonexistent")
+
+    broken_service = MusicService(load_config(), ai_client=WrongAI())
+
+    with pytest.raises(RecommendationUnavailableError):
+        broken_service.recommend("fantasy", ["battle"])


### PR DESCRIPTION
## Summary
- normalize передаваемые теги и добавлять поле tags_text, чтобы повторять контракт существующего AI-эндпоинта
- расширить парсинг ответа нейросервиса, поддерживая вложенные структуры и альтернативные названия полей
- обновить тесты клиента и документацию, убрав упоминания BeerWednesday

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e20c85f9c483239e8dd448f45cedca