### PR TITLE
Add Python module entry point for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,29 @@
 ## Запуск
 ```bash
 pip install -e .[dev]
-uvicorn app.api:app --reload
+
+# локальный запуск с автообновлением
+UVICORN_RELOAD=1 python -m app
 ```
 
 По умолчанию используется конфигурация `config/default.yaml`. Чтобы подключить другой файл, задайте переменную окружения `MUSIC_CONFIG_PATH`:
 
 ```bash
-MUSIC_CONFIG_PATH=./config/custom.yaml uvicorn app.api:app
+MUSIC_CONFIG_PATH=./config/custom.yaml python -m app
 ```
+
+### Деплой на Render (и похожих PaaS)
+
+Render передаёт порт через переменную окружения `PORT`. Скрипт `python -m app`
+поднимет uvicorn на `0.0.0.0:$PORT`, поэтому в настройках сервиса укажите
+команду запуска:
+
+```bash
+python -m app
+```
+
+При необходимости дополнительно задайте переменные окружения, например
+`MUSIC_CONFIG_PATH`.
 
 ## API
 ### Поиск сцены вручную

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,39 @@
+"""Application entry point for running with ``python -m app``.
+
+This helper reads the standard ``PORT`` environment variable (used by
+Render, Railway и другие PaaS-платформы) и пробрасывает его в uvicorn,
+параллельно заставляя сервер слушать внешний интерфейс ``0.0.0.0``.
+
+Локально можно включить автоматический перезапуск, установив
+переменную окружения ``UVICORN_RELOAD=1``.
+"""
+from __future__ import annotations
+
+import os
+
+import uvicorn
+
+
+def _strtobool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def main() -> None:
+    """Run the FastAPI app under uvicorn with sensible defaults."""
+
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    reload = _strtobool(os.getenv("UVICORN_RELOAD"))
+
+    uvicorn.run(
+        "app.api:app",
+        host=host,
+        port=port,
+        reload=reload,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a python -m app entry point that binds uvicorn to 0.0.0.0 and honours the PORT env var
- document the new entry point and Render deployment command in the README

## Testing
- pytest *(fails: missing optional dev dependencies such as fastapi/httpx/yaml in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e22dc4c17083238dea0c3c545c9c32