### PR TITLE
Handle HEAD requests on health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,29 @@
 ## Запуск
 ```bash
 pip install -e .[dev]
-uvicorn app.api:app --reload
+
+# локальный запуск с автообновлением
+UVICORN_RELOAD=1 python -m app
 ```
 
 По умолчанию используется конфигурация `config/default.yaml`. Чтобы подключить другой файл, задайте переменную окружения `MUSIC_CONFIG_PATH`:
 
 ```bash
-MUSIC_CONFIG_PATH=./config/custom.yaml uvicorn app.api:app
+MUSIC_CONFIG_PATH=./config/custom.yaml python -m app
 ```
+
+### Деплой на Render (и похожих PaaS)
+
+Render передаёт порт через переменную окружения `PORT`. Скрипт `python -m app`
+поднимет uvicorn на `0.0.0.0:$PORT`, поэтому в настройках сервиса укажите
+команду запуска:
+
+```bash
+python -m app
+```
+
+При необходимости дополнительно задайте переменные окружения, например
+`MUSIC_CONFIG_PATH`.
 
 ## API
 ### Поиск сцены вручную

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,39 @@
+"""Application entry point for running with ``python -m app``.
+
+This helper reads the standard ``PORT`` environment variable (used by
+Render, Railway и другие PaaS-платформы) и пробрасывает его в uvicorn,
+параллельно заставляя сервер слушать внешний интерфейс ``0.0.0.0``.
+
+Локально можно включить автоматический перезапуск, установив
+переменную окружения ``UVICORN_RELOAD=1``.
+"""
+from __future__ import annotations
+
+import os
+
+import uvicorn
+
+
+def _strtobool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def main() -> None:
+    """Run the FastAPI app under uvicorn with sensible defaults."""
+
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    reload = _strtobool(os.getenv("UVICORN_RELOAD"))
+
+    uvicorn.run(
+        "app.api:app",
+        host=host,
+        port=port,
+        reload=reload,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/app/api.py
+++ b/app/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from functools import lru_cache
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, Response
 from fastapi.templating import Jinja2Templates
 
 from .config import load_config
@@ -51,6 +51,15 @@ def get_service() -> MusicService:
 @app.get("/", response_model=HealthStatus)
 async def health(service: MusicService = Depends(get_service)) -> HealthStatus:
     return HealthStatus(genres=list(service.available_genres()))
+
+
+@app.head("/")
+async def health_head(service: MusicService = Depends(get_service)) -> Response:
+    """Lightweight HEAD variant of the health endpoint for platform probes."""
+
+    # Touch the service so dependency validation matches the GET handler.
+    service.available_genres()
+    return Response(status_code=200)
 
 
 @app.get("/ui", response_class=HTMLResponse)


### PR DESCRIPTION
## Summary
- add a dedicated HEAD handler for the root health check so platform probes succeed

## Testing
- pytest *(fails: missing optional dev dependencies such as fastapi/httpx/yaml in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e22dc4c17083238dea0c3c545c9c32