### PR TITLE
Serve UI at root and move health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,34 @@
 ## Запуск
 ```bash
 pip install -e .[dev]
-uvicorn app.api:app --reload
+
+# локальный запуск с автообновлением
+UVICORN_RELOAD=1 python -m app
 ```
 
 По умолчанию используется конфигурация `config/default.yaml`. Чтобы подключить другой файл, задайте переменную окружения `MUSIC_CONFIG_PATH`:
 
 ```bash
-MUSIC_CONFIG_PATH=./config/custom.yaml uvicorn app.api:app
+MUSIC_CONFIG_PATH=./config/custom.yaml python -m app
 ```
+
+### Деплой на Render (и похожих PaaS)
+
+Render передаёт порт через переменную окружения `PORT`. Скрипт `python -m app`
+поднимет uvicorn на `0.0.0.0:$PORT`, поэтому в настройках сервиса укажите
+команду запуска:
+
+```bash
+python -m app
+```
+
+При необходимости дополнительно задайте переменные окружения, например
+`MUSIC_CONFIG_PATH`.
+
+Главная страница (`/`) отдаёт веб-интерфейс. Для автоматических проверок
+используйте health-эндпоинт `GET /health` (возвращает JSON со списком жанров).
+Пробный HEAD-запрос к `/` или `/health` также вернёт HTTP 200 без тела, что
+совместимо с порт-чеками Render.
 
 ## API
 ### Поиск сцены вручную

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,39 @@
+"""Application entry point for running with ``python -m app``.
+
+This helper reads the standard ``PORT`` environment variable (used by
+Render, Railway и другие PaaS-платформы) и пробрасывает его в uvicorn,
+параллельно заставляя сервер слушать внешний интерфейс ``0.0.0.0``.
+
+Локально можно включить автоматический перезапуск, установив
+переменную окружения ``UVICORN_RELOAD=1``.
+"""
+from __future__ import annotations
+
+import os
+
+import uvicorn
+
+
+def _strtobool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def main() -> None:
+    """Run the FastAPI app under uvicorn with sensible defaults."""
+
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    reload = _strtobool(os.getenv("UVICORN_RELOAD"))
+
+    uvicorn.run(
+        "app.api:app",
+        host=host,
+        port=port,
+        reload=reload,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,7 +16,7 @@ def test_health_endpoint(monkeypatch) -> None:
     monkeypatch.setenv("MUSIC_CONFIG_PATH", "config/default.yaml")
     _reset_caches()
     client = TestClient(app)
-    response = client.get("/")
+    response = client.get("/health")
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
@@ -84,4 +84,16 @@ def test_ui_page(monkeypatch) -> None:
     body = response.text
     assert "RPG Auto-DJ" in body
     # embedded JSON with genres should be present in the page
+    assert "initialData" in body
+
+
+def test_root_serves_ui(monkeypatch) -> None:
+    monkeypatch.setenv("MUSIC_CONFIG_PATH", "config/default.yaml")
+    _reset_caches()
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    body = response.text
+    assert "RPG Auto-DJ" in body
     assert "initialData" in body


### PR DESCRIPTION
## Summary
- serve the HTML UI from the root path while keeping a lightweight HEAD handler for platform probes
- move the JSON health check to `/health` with a dedicated HEAD variant
- document the new routing and update API tests to cover the root UI

## Testing
- pytest *(fails: missing optional dependencies such as fastapi/httpx/yaml in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e22dc4c17083238dea0c3c545c9c32