### PR TITLE
Serve UI from root path

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,16 @@
+import json
+import re
+
 from fastapi.testclient import TestClient
 
-from app.api import app, get_ai_client, get_config, get_service, get_service_cached
+from app.api import (
+    app,
+    get_ai_client,
+    get_config,
+    get_service,
+    get_service_cached,
+    _encode_initial_payload,
+)
 from app.music_service import MusicService
 from app.config import load_config
 from app.ai_client import ScenePrediction
@@ -16,7 +26,7 @@ def test_health_endpoint(monkeypatch) -> None:
     monkeypatch.setenv("MUSIC_CONFIG_PATH", "config/default.yaml")
     _reset_caches()
     client = TestClient(app)
-    response = client.get("/")
+    response = client.get("/health")
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
@@ -74,14 +84,49 @@ def test_recommend_endpoint(monkeypatch) -> None:
         app.dependency_overrides.clear()
 
 
-def test_ui_page(monkeypatch) -> None:
-    monkeypatch.setenv("MUSIC_CONFIG_PATH", "config/default.yaml")
-    _reset_caches()
-    client = TestClient(app)
-    response = client.get("/ui")
+def _assert_ui_page(response) -> None:
     assert response.status_code == 200
     assert "text/html" in response.headers.get("content-type", "")
     body = response.text
     assert "RPG Auto-DJ" in body
-    # embedded JSON with genres should be present in the page
-    assert "initialData" in body
+
+    match = re.search(r"const initialData = (.*?);", body, re.S)
+    assert match is not None, "initialData payload is not embedded in the page"
+
+    payload = json.loads(match.group(1))
+    assert payload["genres"], "Список жанров должен быть заполнен"
+    assert "scenes" in payload and payload["scenes"], "Ожидаем метаданные сцен"
+    assert "hysteresis" in payload and payload["hysteresis"], "Должны быть настройки антидребезга"
+
+    # Проверяем, что опасные последовательности экранированы и не ломают <script>.
+    assert "</script" not in match.group(1)
+
+
+def test_ui_page(monkeypatch) -> None:
+    monkeypatch.setenv("MUSIC_CONFIG_PATH", "config/default.yaml")
+    _reset_caches()
+    client = TestClient(app)
+    _assert_ui_page(client.get("/"))
+    _assert_ui_page(client.get("/ui"))
+
+
+def test_payload_encoding_matches_jinja_escape() -> None:
+    payload = {
+        "text": "</script> Tom & Jerry's <b>adventure</b> \u2028",
+    }
+    encoded = _encode_initial_payload(payload)
+
+    # JSON строка должна корректно парситься обратно.
+    assert json.loads(encoded) == {
+        "text": "</script> Tom & Jerry's <b>adventure</b> \u2028",
+    }
+
+    # Повторяем ключевые экранирования Jinja: угловые скобки, апострофы, амперсанды.
+    assert "<" not in encoded
+    assert ">" not in encoded
+    assert "&" not in encoded
+    assert "'" not in encoded
+    assert "\\u003c" in encoded and "\\u003e" in encoded
+    assert "\\u0026" in encoded and "\\u0027" in encoded
+    # Специальные символы разделителей не должны попадать в сыром виде.
+    assert "\u2028" not in encoded


### PR DESCRIPTION
## Summary
- render the UI HTML from the root endpoint while keeping /ui as an alias
- expose the previous JSON health payload via /health and keep the head probe there
- refactor UI initial data preparation into helpers reused by both endpoints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2433bfb68832395713e3bf29271ab