### PR TITLE
Fix AI client request payload structure

### DIFF
--- a/app/ai_client.py
+++ b/app/ai_client.py
@@ -44,9 +44,11 @@ class NeuralTaggerClient:
 
     def recommend_scene(self, genre: str, tags: Iterable[str]) -> ScenePrediction:
         normalized_tags = [str(tag) for tag in tags if str(tag).strip()]
-        payload: dict[str, object] = {"genre": genre, "tags": normalized_tags}
+        inputs_payload: dict[str, object] = {"genre": genre, "tags": normalized_tags}
         if normalized_tags:
-            payload["tags_text"] = ", ".join(normalized_tags)
+            inputs_payload["tags_text"] = ", ".join(normalized_tags)
+
+        payload: dict[str, object] = {"inputs": inputs_payload}
         headers = {"Content-Type": "application/json"}
         if self._token:
             headers["Authorization"] = f"Bearer {self._token}"

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -10,9 +10,10 @@ def test_neural_client_success() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "POST"
         payload = json.loads(request.content.decode())
-        assert payload["genre"] == "fantasy"
-        assert payload["tags"] == ["battle"]
-        assert payload["tags_text"] == "battle"
+        inputs = payload["inputs"]
+        assert inputs["genre"] == "fantasy"
+        assert inputs["tags"] == ["battle"]
+        assert inputs["tags_text"] == "battle"
         return httpx.Response(200, json={"scene": "battle", "confidence": 0.88, "reason": "stub"})
 
     client = NeuralTaggerClient(endpoint="http://test", transport=httpx.MockTransport(handler))
@@ -34,7 +35,7 @@ def test_neural_client_error_status() -> None:
 def test_neural_client_nested_scene() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         payload = json.loads(request.content.decode())
-        assert payload["tags_text"] == "battle, dragons"
+        assert payload["inputs"]["tags_text"] == "battle, dragons"
         return httpx.Response(
             200,
             json={


### PR DESCRIPTION
## Summary
- wrap the neural tagger request body inside an `inputs` envelope to match the external API
- adjust client tests to expect the new payload layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e252dc4c108323828a647feca3d0fe