### PR TITLE
Refine prompt generation for neural tagger

### DIFF
--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -13,6 +13,7 @@ def test_neural_client_success() -> None:
         inputs = payload["inputs"]
         assert inputs["genre"] == "fantasy"
         assert inputs["tags"] == ["battle"]
+        assert inputs["prompt"] == "Жанр: fantasy. Теги: battle"
         assert inputs["tags_text"] == "battle"
         return httpx.Response(200, json={"scene": "battle", "confidence": 0.88, "reason": "stub"})
 
@@ -35,6 +36,7 @@ def test_neural_client_error_status() -> None:
 def test_neural_client_nested_scene() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         payload = json.loads(request.content.decode())
+        assert payload["inputs"]["prompt"] == "Жанр: fantasy. Теги: battle, dragons"
         assert payload["inputs"]["tags_text"] == "battle, dragons"
         return httpx.Response(
             200,
@@ -51,3 +53,29 @@ def test_neural_client_nested_scene() -> None:
     assert prediction.scene == "battle"
     assert prediction.confidence == pytest.approx(0.73)
     assert prediction.reason == "extra"
+
+
+def test_neural_client_fallback_prompt() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode())
+        assert payload["inputs"]["tags"] == []
+        assert payload["inputs"]["prompt"] == "Жанр: fantasy"
+        assert "tags_text" not in payload["inputs"]
+        return httpx.Response(200, json={"scene": "city"})
+
+    client = NeuralTaggerClient(endpoint="http://test", transport=httpx.MockTransport(handler))
+    prediction = client.recommend_scene("fantasy", [])
+    assert prediction.scene == "city"
+
+
+def test_neural_client_prompt_without_genre_and_tags() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode())
+        assert payload["inputs"]["genre"] == ""
+        assert payload["inputs"]["tags"] == []
+        assert payload["inputs"]["prompt"] == "Музыкальная сцена"
+        return httpx.Response(200, json={"scene": "mystery"})
+
+    client = NeuralTaggerClient(endpoint="http://test", transport=httpx.MockTransport(handler))
+    prediction = client.recommend_scene("", [" ", ""])
+    assert prediction.scene == "mystery"


### PR DESCRIPTION
## Summary
- sanitize incoming tags before building the neural request payload
- generate a descriptive prompt that includes genre and tags with a reasonable fallback
- expand client tests to cover the new prompt formatting and empty-input behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4bd635a2c8323807e59cd8f750104