### PR TITLE
Improve neural client error reporting

### DIFF
--- a/app/ai_client.py
+++ b/app/ai_client.py
@@ -68,7 +68,13 @@ class NeuralTaggerClient:
             with httpx.Client(timeout=self._timeout, transport=self._transport) as client:
                 response = client.post(self._endpoint, json=payload, headers=headers)
         except httpx.HTTPError as exc:  # pragma: no cover - сеть может вести себя по-разному
-            raise NeuralTaggerError("Не удалось обратиться к сервису рекомендаций") from exc
+            details = str(exc).strip()
+            message = "Не удалось обратиться к сервису рекомендаций"
+            if self._endpoint:
+                message = f"{message} ({self._endpoint})"
+            if details:
+                message = f"{message}: {details}"
+            raise NeuralTaggerError(message) from exc
 
         if response.status_code != 200:
             raise NeuralTaggerError(

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -79,3 +79,14 @@ def test_neural_client_prompt_without_genre_and_tags() -> None:
     client = NeuralTaggerClient(endpoint="http://test", transport=httpx.MockTransport(handler))
     prediction = client.recommend_scene("", [" ", ""])
     assert prediction.scene == "mystery"
+
+
+def test_neural_client_error_contains_details() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    client = NeuralTaggerClient(endpoint="http://test", transport=httpx.MockTransport(handler))
+    with pytest.raises(NeuralTaggerError) as error:
+        client.recommend_scene("fantasy", ["battle"])
+
+    assert "Не удалось обратиться к сервису рекомендаций (http://test): boom" in str(error.value)


### PR DESCRIPTION
## Summary
- include endpoint and original exception text when neural tagger HTTP calls fail
- add regression test ensuring detailed error message is exposed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4c485a3948323a2ee22172fc08789