### PR TITLE
Adjust AI client payload for compatibility with recommendation service

### DIFF
--- a/app/ai_client.py
+++ b/app/ai_client.py
@@ -54,15 +54,19 @@ class NeuralTaggerClient:
         genre_text = str(genre).strip()
         tags_text = ", ".join(normalized_tags)
         prompt = self._build_prompt(genre_text, normalized_tags)
-        inputs_payload: dict[str, object] = {
-            "genre": genre,
-            "tags": normalized_tags,
-            "prompt": prompt,
-        }
+        inputs_payload: dict[str, object] = {"prompt": prompt}
+
+        parameters: dict[str, object] = {}
+        if genre_text:
+            parameters["genre"] = genre_text
+        if normalized_tags:
+            parameters["tags"] = normalized_tags
         if tags_text:
-            inputs_payload["tags_text"] = tags_text
+            parameters["tags_text"] = tags_text
 
         payload: dict[str, object] = {"inputs": inputs_payload}
+        if parameters:
+            payload["parameters"] = parameters
         headers = {"Content-Type": "application/json"}
         if self._token:
             headers["Authorization"] = f"Bearer {self._token}"


### PR DESCRIPTION
## Summary
- adjust the AI client request payload to keep metadata separate from the prompt so it no longer sends unsupported keyword arguments
- update the neural client unit tests to cover the new payload structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4ccf9d3b083238fd9844550a436d9