### PR TITLE
Fix AI client payload to remove unsupported parameters

### DIFF
--- a/app/ai_client.py
+++ b/app/ai_client.py
@@ -52,21 +52,10 @@ class NeuralTaggerClient:
             if tag_text:
                 normalized_tags.append(tag_text)
         genre_text = str(genre).strip()
-        tags_text = ", ".join(normalized_tags)
         prompt = self._build_prompt(genre_text, normalized_tags)
         inputs_payload: dict[str, object] = {"prompt": prompt}
 
-        parameters: dict[str, object] = {}
-        if genre_text:
-            parameters["genre"] = genre_text
-        if normalized_tags:
-            parameters["tags"] = normalized_tags
-        if tags_text:
-            parameters["tags_text"] = tags_text
-
         payload: dict[str, object] = {"inputs": inputs_payload}
-        if parameters:
-            payload["parameters"] = parameters
         headers = {"Content-Type": "application/json"}
         if self._token:
             headers["Authorization"] = f"Bearer {self._token}"

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -12,9 +12,7 @@ def test_neural_client_success() -> None:
         payload = json.loads(request.content.decode())
         inputs = payload["inputs"]
         assert inputs == {"prompt": "Жанр: fantasy. Теги: battle"}
-        assert payload["parameters"]["genre"] == "fantasy"
-        assert payload["parameters"]["tags"] == ["battle"]
-        assert payload["parameters"]["tags_text"] == "battle"
+        assert "parameters" not in payload
         return httpx.Response(200, json={"scene": "battle", "confidence": 0.88, "reason": "stub"})
 
     client = NeuralTaggerClient(endpoint="http://test", transport=httpx.MockTransport(handler))
@@ -37,7 +35,7 @@ def test_neural_client_nested_scene() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         payload = json.loads(request.content.decode())
         assert payload["inputs"] == {"prompt": "Жанр: fantasy. Теги: battle, dragons"}
-        assert payload["parameters"]["tags_text"] == "battle, dragons"
+        assert "parameters" not in payload
         return httpx.Response(
             200,
             json={
@@ -59,8 +57,7 @@ def test_neural_client_fallback_prompt() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         payload = json.loads(request.content.decode())
         assert payload["inputs"] == {"prompt": "Жанр: fantasy"}
-        assert "tags" not in payload.get("parameters", {})
-        assert "tags_text" not in payload.get("parameters", {})
+        assert "parameters" not in payload
         return httpx.Response(200, json={"scene": "city"})
 
     client = NeuralTaggerClient(endpoint="http://test", transport=httpx.MockTransport(handler))


### PR DESCRIPTION
## Summary
- stop including the genre/tags parameters in the neural tagger payload so the upstream service accepts requests
- update the client tests to reflect the new minimal payload structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4d32b754c8323ac792ae14f954ac3