### PR TITLE
Handle Hugging Face inference payloads

### DIFF
--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -53,6 +53,21 @@ def test_neural_client_nested_scene() -> None:
     assert prediction.reason == "extra"
 
 
+def test_neural_client_huggingface_payload() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode())
+        assert payload["inputs"] == "Жанр: fantasy. Теги: battle"
+        return httpx.Response(200, json={"scene": "battle"})
+
+    client = NeuralTaggerClient(
+        endpoint="https://api-inference.huggingface.co/models/demo",
+        transport=httpx.MockTransport(handler),
+    )
+
+    prediction = client.recommend_scene("fantasy", ["battle"])
+    assert prediction.scene == "battle"
+
+
 def test_neural_client_fallback_prompt() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         payload = json.loads(request.content.decode())


### PR DESCRIPTION
## Summary
- detect Hugging Face endpoints in the neural tagger client and switch to plain prompt payloads they expect
- keep the existing JSON structure for other endpoints so on-prem services continue working
- cover the new behaviour with a dedicated unit test for Hugging Face URLs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4d557a5848323bcc810c8f8090446